### PR TITLE
change el to current in reduce in solutions

### DIFF
--- a/.index.solution.js
+++ b/.index.solution.js
@@ -1,30 +1,30 @@
 function map(array, fn) {
-  return array.reduce(function(acc, el) {
-    return acc.concat(fn(el));
+  return array.reduce(function(acc, current) {
+    return acc.concat(fn(current));
   }, []);
 }
 
 function filter(array, fn) {
-  return array.reduce(function(acc, el) {
-    return fn(el) ? acc.concat(el) : acc;
+  return array.reduce(function(acc, current) {
+    return fn(current) ? acc.concat(current) : acc;
   }, []);
 }
 
 function some(array, fn) {
-  return array.reduce(function(acc, el) {
-    return acc || fn(el);
+  return array.reduce(function(acc, current) {
+    return acc || fn(current);
   }, false);
 }
 
 function every(array, fn) {
-  return array.reduce(function(acc, el) {
-    return acc && fn(el);
+  return array.reduce(function(acc, current) {
+    return acc && fn(current);
   }, true);
 }
 
 function join(array, string) {
-  return array.reduce(function(acc, el) {
-    return acc + string + el;
+  return array.reduce(function(acc, current) {
+    return acc + string + current;
   });
 }
 


### PR DESCRIPTION
in order to make things clearer in the solutions, and in line with the format [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce) use (`(acc, current) => ` or some variation), this PR changes `el` to `current` in the solutions.

fix #3 

@shiryz feel free to merge if you approve.